### PR TITLE
Fetching pipeline groups should be done via admin/pipeline_groups

### DIFF
--- a/gocd/gocd.go
+++ b/gocd/gocd.go
@@ -32,6 +32,8 @@ const (
 	apiV3 = "application/vnd.go.cd.v3+json"
 	// Version 4 of the GoCD API.
 	apiV4 = "application/vnd.go.cd.v4+json"
+	// Latest api version
+	apiLatest = "application/vnd.go.cd+json"
 )
 
 //Body Response Types

--- a/gocd/pipeline.go
+++ b/gocd/pipeline.go
@@ -157,6 +157,7 @@ func (pgs *PipelinesService) GetHistory(ctx context.Context, name string, offset
 	pt = &PipelineHistory{}
 	_, resp, err = pgs.client.getAction(ctx, &APIClientRequest{
 		Path:         pgs.buildPaginatedStub("pipelines/%s/history", name, offset),
+		APIVersion:   apiLatest,
 		ResponseBody: &pt,
 	})
 

--- a/gocd/pipelinegroups.go
+++ b/gocd/pipelinegroups.go
@@ -16,23 +16,29 @@ type PipelineGroup struct {
 
 // List Pipeline groups
 func (pgs *PipelineGroupsService) List(ctx context.Context, name string) (*PipelineGroups, *APIResponse, error) {
-
-	pg := []*PipelineGroup{}
+	type EmbeddedObj struct {
+		PipelineGroup []*PipelineGroup `json:"groups"`
+	}
+	type AllPipelineGroupsResponse struct {
+		Embedded EmbeddedObj `json:"_embedded"`
+	}
+	pg := new(AllPipelineGroupsResponse)
 	_, resp, err := pgs.client.getAction(ctx, &APIClientRequest{
-		Path:         "config/pipeline_groups",
+		Path:         "admin/pipeline_groups",
+		APIVersion:   apiLatest,
 		ResponseType: responseTypeJSON,
 		ResponseBody: &pg,
 	})
 
 	filtered := PipelineGroups{}
 	if name != "" && err == nil {
-		for _, pipelineGroup := range pg {
+		for _, pipelineGroup := range pg.Embedded.PipelineGroup {
 			if pipelineGroup.Name == name {
 				filtered = append(filtered, pipelineGroup)
 			}
 		}
 	} else {
-		filtered = pg
+		filtered = pg.Embedded.PipelineGroup
 	}
 
 	return &filtered, resp, err

--- a/gocd/pipelinegroups_test.go
+++ b/gocd/pipelinegroups_test.go
@@ -18,7 +18,7 @@ func testPipelineGroupsServiceFilter(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/api/config/pipeline_groups", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/admin/pipeline_groups", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
 		j, _ := ioutil.ReadFile("test/resources/pipelinegroups.1.json")
 		fmt.Fprint(w, string(j))
@@ -36,7 +36,7 @@ func testPipelineGroupsServiceList(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/api/config/pipeline_groups", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/admin/pipeline_groups", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
 		j, _ := ioutil.ReadFile("test/resources/pipelinegroups.0.json")
 		fmt.Fprint(w, string(j))
@@ -53,15 +53,4 @@ func testPipelineGroupsServiceList(t *testing.T) {
 
 	p := pg.Pipelines[0]
 	assert.Equal(t, p.Name, "up42")
-	assert.Equal(t, p.Label, "${COUNT}")
-	assert.Len(t, p.Stages, 1)
-	assert.Len(t, p.Materials, 1)
-
-	s := p.Stages[0]
-	assert.Equal(t, s.Name, "up42_stage")
-
-	m := p.Materials[0]
-	assert.Equal(t, m.Type, "Git")
-	assert.Equal(t, m.Fingerprint, "2d05446cd52a998fe3afd840fc2c46b7c7e421051f0209c7f619c95bedc28b88")
-	assert.Equal(t, m.Description, "URL: https://github.com/gocd/gocd, Branch: master")
 }

--- a/gocd/test/resources/pipelinegroups.0.json
+++ b/gocd/test/resources/pipelinegroups.0.json
@@ -1,23 +1,14 @@
-[
-  {
-    "pipelines": [
+{
+  "_embedded": {
+    "groups": [
       {
-        "stages": [
+        "name": "first",
+        "pipelines": [
           {
-            "name": "up42_stage"
+            "name": "up42"
           }
-        ],
-        "name": "up42",
-        "materials": [
-          {
-            "description": "URL: https://github.com/gocd/gocd, Branch: master",
-            "fingerprint": "2d05446cd52a998fe3afd840fc2c46b7c7e421051f0209c7f619c95bedc28b88",
-            "type": "Git"
-          }
-        ],
-        "label": "${COUNT}"
+        ]
       }
-    ],
-    "name": "first"
+    ]
   }
-]
+}

--- a/gocd/test/resources/pipelinegroups.1.json
+++ b/gocd/test/resources/pipelinegroups.1.json
@@ -1,44 +1,22 @@
-[
-  {
-    "pipelines": [
+{
+  "_embedded": {
+    "groups": [
       {
-        "stages": [
+        "name": "first",
+        "pipelines": [
           {
-            "name": "up42_stage"
+            "name": "up42"
           }
-        ],
-        "name": "up42",
-        "materials": [
-          {
-            "description": "URL: https://github.com/gocd/gocd, Branch: master",
-            "fingerprint": "2d05446cd52a998fe3afd840fc2c46b7c7e421051f0209c7f619c95bedc28b88",
-            "type": "Git"
-          }
-        ],
-        "label": "${COUNT}"
-      }
-    ],
-    "name": "first"
-  },
-  {
-    "pipelines": [
+        ]
+      },
       {
-        "stages": [
+        "name": "filter-group",
+        "pipelines": [
           {
-            "name": "filter_pl_stage"
+            "name": "filter_pl"
           }
-        ],
-        "name": "filter_pl",
-        "materials": [
-          {
-            "description": "URL: https://github.com/gocd/gocd, Branch: master",
-            "fingerprint": "2d05446cd52a998fe3afd840fc2c46b7c7e421051f0209c7f619c95bedc28b88",
-            "type": "Git"
-          }
-        ],
-        "label": "${COUNT}-filter"
+        ]
       }
-    ],
-    "name": "filter-group"
+    ]
   }
-]
+}


### PR DESCRIPTION
config/pipeline_groups has been deprecated in GoCD. Updated the
PipelineGroupsService api to use the new GoCD endpoint.