### PR TITLE
Further API updates to support 20.3.0

### DIFF
--- a/gocd/pipeline.go
+++ b/gocd/pipeline.go
@@ -152,11 +152,11 @@ func (pgs *PipelinesService) GetInstance(ctx context.Context, name string, offse
 }
 
 // GetHistory returns a list of pipeline instances describing the pipeline history.
-func (pgs *PipelinesService) GetHistory(ctx context.Context, name string, offset int) (pt *PipelineHistory, resp *APIResponse, err error) {
+func (pgs *PipelinesService) GetHistory(ctx context.Context, name string, page_size int) (pt *PipelineHistory, resp *APIResponse, err error) {
 
 	pt = &PipelineHistory{}
 	_, resp, err = pgs.client.getAction(ctx, &APIClientRequest{
-		Path:         pgs.buildPaginatedStub("pipelines/%s/history", name, offset),
+		Path:         fmt.Sprintf("pipelines/%s/history?page_size=%d", name, page_size),
 		APIVersion:   apiLatest,
 		ResponseBody: &pt,
 	})

--- a/gocd/stage_instance.go
+++ b/gocd/stage_instance.go
@@ -12,5 +12,5 @@ type StageInstance struct {
 	Counter           string `json:"counter,omitempty"`
 	OperatePermission bool   `json:"operate_permission,omitempty"`
 	Result            string `json:"result,omitempty"`
-	RerunOfCounter    string `json:"rerun_of_counter,omitempty"`
+	RerunOfCounter    int    `json:"rerun_of_counter,omitempty"`
 }

--- a/gocd/stage_instance_test.go
+++ b/gocd/stage_instance_test.go
@@ -41,6 +41,7 @@ func testStageInstanceJSONString(t *testing.T) {
 		ID:                13,
 		OperatePermission: true,
 		Scheduled:         true,
+		RerunOfCounter:    1,
 	}
 	j, err := s.JSONString()
 	if err != nil {
@@ -65,7 +66,8 @@ func testStageInstanceJSONString(t *testing.T) {
   "approved_by": "admin",
   "counter": "1",
   "operate_permission": true,
-  "result": "Failed"
+  "result": "Failed",
+  "rerun_of_counter": 1
 }`, j)
 }
 

--- a/gocd/test/resources/pipeline.1.json
+++ b/gocd/test/resources/pipeline.1.json
@@ -1,4 +1,12 @@
 {
+  "_links": {
+    "next": {
+      "href": "http://ci.example.com/go/api/pipelines/pipeline1/history?after=35"
+    },
+    "previous": {
+      "href": "http://ci.example.com/go/api/pipelines/pipeline1/history?before=9"
+    }
+  },
   "pipelines": [
     {
       "build_cause": {
@@ -118,10 +126,5 @@
       "preparing_to_schedule": false,
       "label": "10"
     }
-  ],
-  "pagination": {
-    "offset": 0,
-    "total": 2,
-    "page_size": 10
-  }
+  ]
 }


### PR DESCRIPTION
Updated StageInstance to the correct type of `rerun_of_counter`, it is now an int.

Updated Pipeline GetHistory to use `page_size` instead of `offset`. This will only get the first `page_size` history items. I think this is good enough for now as we only use this from the gocd-cleaner and should be able to find the green and red builds to keep from that `page_size` subset.

As this lib is more or less dead I don't think it's worth spending more time implementing full support for the GoCD API...